### PR TITLE
Various fixes: basic Dockerfile and tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+#
+# Prior to use this Dockerfile, please use the following commands:
+#
+# git clone https://github.com/opengeospatial/teamengine src
+# git clone https://github.com/opengeospatial/ets-common.git src1
+# cd src1
+# git clone -b testbed17 https://github.com/opengeospatial/ets-ogcapi-processes10.git
+#
+
+#
+# Build stage
+#
+FROM maven:3.8.3-jdk-8-slim AS build
+ARG BUILD_DEPS=" \
+    git \
+"
+COPY src /home/app/src
+COPY src1 /home/app/src1
+RUN apt-get update && \
+    apt-get install -y $BUILD_DEPS && \
+    echo "teamengine building..." && \
+    mvn -f /home/app/src/pom.xml clean install > log && \
+    mvn -f /home/app/src1/ets-ogcapi-processes10/pom.xml clean install && \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $BUILD_DEPS && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM tomcat:7.0-jre8
+ARG BUILD_DEPS=" \
+    unzip \
+"
+COPY --from=build /home/app/src/teamengine-web/target/teamengine*.war /root
+COPY --from=build /home/app/src/teamengine-web/target/teamengine-*common-libs.zip /root
+COPY --from=build /home/app/src/teamengine-console/target/teamengine-console-*-base.zip /root
+COPY --from=build /home/app/src1/ets-ogcapi-processes10/target/ets-ogcapi-processes10-*-ctl.zip /root
+COPY --from=build /home/app/src1/ets-ogcapi-processes10/target/ets-ogcapi-processes10-*-deps.zip /root
+ENV JAVA_OPTS="-Xms1024m -Xmx2048m -DTE_BASE=/root/te_base"
+RUN cd /root && \
+    mkdir te_base && \
+    mkdir te_base/scripts && \
+    apt-get update && \
+    apt-get install -y $BUILD_DEPS && \
+    unzip -q -o teamengine*.war -d /usr/local/tomcat/webapps/teamengine && \
+    unzip -q -o teamengine-*common-libs.zip -d /usr/local/tomcat/lib && \
+    unzip -q -o teamengine-console-*-base.zip -d /root/te_base && \
+    unzip -q -o ets-ogcapi-processes10-*-ctl.zip -d /root/te_base/scripts && \
+    unzip -q -o ets-ogcapi-processes10-*-deps.zip -d /usr/local/tomcat/webapps/teamengine/WEB-INF/lib && \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $BUILD_DEPS && \
+    rm -rf /var/lib/apt/lists/* /root/*zip /root/*war
+
+
+# run tomcat
+CMD ["catalina.sh", "jpda", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,34 @@
 #
 # Prior to use this Dockerfile, please use the following commands:
 #
+# mkdir CITE
+# cd CITE
 # git clone https://github.com/opengeospatial/teamengine src
 # git clone https://github.com/opengeospatial/ets-common.git src1
 # cd src1
 # git clone -b testbed17 https://github.com/opengeospatial/ets-ogcapi-processes10.git
+# cp ets-ogcapi-processes10/Dockerfile ..
+# cd ..
+#
+
+#
+# Go inside the CITE directory
+# Build with the following command:
+# docker build . -t teamengine/ogcapi-processes:latest
+# Run using the following command:
+# docker run -d --name cite-teamengine -p 8080:8080 teamengine/ogcapi-processes:latest
+# Log using the following command:
+# docker logs -f cite-teamengine
+# Stop using the following command:
+# docker stop cite-teamengine
+# Remove using the following command:
+# docker rm cite-teamengine
 #
 
 #
 # Build stage
+#  1. build the teamengine
+#  2. build the Test Suite
 #
 FROM maven:3.8.3-jdk-8-slim AS build
 ARG BUILD_DEPS=" \
@@ -24,6 +44,9 @@ RUN apt-get update && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $BUILD_DEPS && \
     rm -rf /var/lib/apt/lists/*
 
+#
+# Create the container to be run based on tomcat
+#
 FROM tomcat:7.0-jre8
 ARG BUILD_DEPS=" \
     unzip \

--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,7 @@ for more information, including the API documentation.
 
 Run the following commands:
 
+[source,bash]
 git clone https://github.com/opengeospatial/teamengine src
 git clone https://github.com/opengeospatial/ets-common.git src1
 cd src1

--- a/README.adoc
+++ b/README.adoc
@@ -7,6 +7,17 @@ This executable test suite is for the OGC API - Processes draft standard.
 Visit the http://opengeospatial.github.io/ets-ogcapi-processes10/[project documentation website TBD]
 for more information, including the API documentation.
 
+== 2 minutes method
+
+Run the following commands:
+
+git clone https://github.com/opengeospatial/teamengine src
+git clone https://github.com/opengeospatial/ets-common.git src1
+cd src1
+git clone -b testbed17 https://github.com/GeoLabs/ets-ogcapi-processes10.git
+cd ..
+
+
 == How to build the test suite
 
 The test suite is built using https://maven.apache.org/[Apache Maven v3].

--- a/README.adoc
+++ b/README.adoc
@@ -12,11 +12,19 @@ for more information, including the API documentation.
 Run the following commands:
 
 [source,bash]
+mkdir CITE
+cd CITE
 git clone https://github.com/opengeospatial/teamengine src
 git clone https://github.com/opengeospatial/ets-common.git src1
 cd src1
 git clone -b testbed17 https://github.com/GeoLabs/ets-ogcapi-processes10.git
 cd ..
+# Build the docker image
+docker build . -t teamengine/ogcapi-processes:latest
+# Run the docker container 
+docker run -d --name cite-teamengine -p 8080:8080 teamengine/ogcapi-processes:latest
+
+From here, you can now access http://localhost:8080/teamengine to access the deployed teamengine with the OGC API - Processes Test Suite.
 
 
 == How to build the test suite

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,38 @@
 		<artifactId>openapi-operation-validator</artifactId>
 		<version>1.0.7</version>
 	</dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.12.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>2.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger.parser.v3</groupId>
+      <artifactId>swagger-parser</artifactId>
+      <version>2.0.28</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.7</version>
+    </dependency>
+    <dependency>
+      <groupId>com.networknt</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>1.0.63</version>
+    </dependency>
+
     <dependency>
       <groupId>net.jadler</groupId>
       <artifactId>jadler-core</artifactId>

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/CommonFixture.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/CommonFixture.java
@@ -65,7 +65,6 @@ public class CommonFixture {
         rootUri = (URI) testContext.getSuite().getAttribute( SuiteAttribute.IUT.getName() );
         try {
 			specURI = new URI("https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/openapi.yaml");
-//			specURI = new URI("file:///d:/tmp2/geoprocessing-WPS-all-in-one-1.0-draft.7-SNAPSHOT-oas3-swagger.yaml");
 		} catch (URISyntaxException e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/conformance/Conformance.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/conformance/Conformance.java
@@ -41,8 +41,10 @@ import io.restassured.response.Response;
 public class Conformance extends CommonFixture {
 
     private List<RequirementClass> requirementClasses;
-
-    @DataProvider(name = "A.2.3. Conformance Path /conformance")
+    //private static String utrlSchema="http://beta.schemas.opengis.net/ogcapi/common/part1/0.1/core/openapi/schemas/conformance.json";
+    private static String urlSchema="https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/confClasses.yaml";
+    
+    @DataProvider(name = "conformance")
     public Object[][] conformanceUris( ITestContext testContext ) {
         OpenApi3 apiModel = (OpenApi3) testContext.getSuite().getAttribute( API_MODEL.getName() );
         URI iut = (URI) testContext.getSuite().getAttribute( IUT.getName() );
@@ -71,7 +73,7 @@ public class Conformance extends CommonFixture {
      * @param testPoint
      *            the test point to test, never <code>null</code>
      */
-    @Test(description = "Implements /conf/core/conformance-success (partial)", groups = "conformance", dataProvider = "A.2.3. Conformance Path /conformance")
+    @Test(description = "Implements /conf/core/conformance-success (partial)", groups = "A.2.3. Conformance Path /conformance", dataProvider = "conformance")
     public void validateConformanceOperationAndResponse( TestPoint testPoint ) {
         String testPointUri = testPoint.getServerUrl() + testPoint.getPath();
         Response response = init().baseUri( testPointUri ).accept( JSON ).when().request( GET );
@@ -82,13 +84,16 @@ public class Conformance extends CommonFixture {
      * Requirement 1 : /req/processes/core/conformance-success
      *
      * Abstract Test A.2.3.6.1: /conf/core/conformance-success
-     * Abstract Test A.2.3.6.2: /conf/core/conformance-success TODO
+     * Abstract Test A.2.3.6.2: /conf/core/conformance-success 
      * Abstract Test A.2.3.6.3: /conf/core/conformance-success
-     * Abstract Test A.2.3.6.4: /conf/core/conformance-success TODO
+     * Abstract Test A.2.3.6.4: /conf/core/conformance-success TODO / DOABLE?
      */
     private void validateConformanceOperationResponse( String testPointUri, Response response ) {
         response.then().statusCode( 200 );
 
+	assertTrue( validateResponseAgainstSchema(Conformance.urlSchema,response.getBody().asString()),
+		    "Unable to validate the response document against: "+Conformance.urlSchema);
+	
         JsonPath jsonPath = response.jsonPath();
         this.requirementClasses = parseAndValidateRequirementClasses( jsonPath );
         assertTrue( this.requirementClasses.contains( CORE ),

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/conformance/Conformance.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/conformance/Conformance.java
@@ -42,7 +42,8 @@ public class Conformance extends CommonFixture {
 
     private List<RequirementClass> requirementClasses;
     //private static String utrlSchema="http://beta.schemas.opengis.net/ogcapi/common/part1/0.1/core/openapi/schemas/conformance.json";
-    private static String urlSchema="https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/confClasses.yaml";
+    //private static String urlSchema="https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/confClasses.yaml";
+    private static String urlSchema="http://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/confClasses.yaml";
     
     @DataProvider(name = "conformance")
     public Object[][] conformanceUris( ITestContext testContext ) {

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/conformance/Conformance.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/conformance/Conformance.java
@@ -33,7 +33,7 @@ import io.restassured.response.Response;
 
 /**
  *
- * A.?.?. Conformance Path {root}/conformance
+ * A.2.3. Conformance Path {root}/conformance
  *
  *
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
@@ -47,7 +47,7 @@ public class Conformance extends CommonFixture {
         OpenApi3 apiModel = (OpenApi3) testContext.getSuite().getAttribute( API_MODEL.getName() );
         URI iut = (URI) testContext.getSuite().getAttribute( IUT.getName() );
 
-        TestPoint tp = new TestPoint(rootUri.toString(),"/conformance",null);
+        TestPoint tp = new TestPoint(rootUri.toString(),"conformance",null);
 
 
         List<TestPoint> testPoints = new ArrayList<TestPoint>();
@@ -73,7 +73,7 @@ public class Conformance extends CommonFixture {
      */
     @Test(description = "Implements A.?.?. Conformance Path {root}/conformance,", groups = "conformance", dataProvider = "conformanceUris")
     public void validateConformanceOperationAndResponse( TestPoint testPoint ) {
-        String testPointUri = new UriBuilder( testPoint ).buildUrl();
+        String testPointUri = testPoint.getServerUrl() + testPoint.getPath(); //new UriBuilder( testPoint ).buildUrl();
         Response response = init().baseUri( testPointUri ).accept( JSON ).when().request( GET );
         validateConformanceOperationResponse( testPointUri, response );
     }

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/conformance/Conformance.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/conformance/Conformance.java
@@ -42,7 +42,7 @@ public class Conformance extends CommonFixture {
 
     private List<RequirementClass> requirementClasses;
 
-    @DataProvider(name = "conformanceUris")
+    @DataProvider(name = "A.2.3. Conformance Path /conformance")
     public Object[][] conformanceUris( ITestContext testContext ) {
         OpenApi3 apiModel = (OpenApi3) testContext.getSuite().getAttribute( API_MODEL.getName() );
         URI iut = (URI) testContext.getSuite().getAttribute( IUT.getName() );
@@ -67,13 +67,13 @@ public class Conformance extends CommonFixture {
 
     /**
      * Partly addresses Requirement 1 : /req/processes/core/conformance-success
-     *
+     * 
      * @param testPoint
      *            the test point to test, never <code>null</code>
      */
-    @Test(description = "Implements A.?.?. Conformance Path {root}/conformance,", groups = "conformance", dataProvider = "conformanceUris")
+    @Test(description = "Implements /conf/core/conformance-success (partial)", groups = "conformance", dataProvider = "A.2.3. Conformance Path /conformance")
     public void validateConformanceOperationAndResponse( TestPoint testPoint ) {
-        String testPointUri = testPoint.getServerUrl() + testPoint.getPath(); //new UriBuilder( testPoint ).buildUrl();
+        String testPointUri = testPoint.getServerUrl() + testPoint.getPath();
         Response response = init().baseUri( testPointUri ).accept( JSON ).when().request( GET );
         validateConformanceOperationResponse( testPointUri, response );
     }
@@ -81,7 +81,10 @@ public class Conformance extends CommonFixture {
     /**
      * Requirement 1 : /req/processes/core/conformance-success
      *
-     * Abstract Test ?: /ats/core/conformance-success
+     * Abstract Test A.2.3.6.1: /conf/core/conformance-success
+     * Abstract Test A.2.3.6.2: /conf/core/conformance-success TODO
+     * Abstract Test A.2.3.6.3: /conf/core/conformance-success
+     * Abstract Test A.2.3.6.4: /conf/core/conformance-success TODO
      */
     private void validateConformanceOperationResponse( String testPointUri, Response response ) {
         response.then().statusCode( 200 );

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage.java
@@ -1,6 +1,7 @@
 package org.opengis.cite.ogcapiprocesses10.landingpage;
 
 import static io.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.HTML;
 import static io.restassured.http.Method.GET;
 import static org.opengis.cite.ogcapiprocesses10.EtsAssert.assertTrue;
 //import com.atlassian.oai.validator.OpenApiInteractionValidator;
@@ -10,6 +11,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.core.JsonFactory;
+import java.util.HashMap;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.net.URI;
 
 import io.swagger.v3.parser.*;
 import io.swagger.parser.*;
@@ -42,11 +46,13 @@ public class LandingPage extends CommonFixture {
 
     private JsonPath response;
     private String body;
-
+    
+    //private static String utrlSchema="http://beta.schemas.opengis.net/ogcapi/common/part1/0.1/core/openapi/schemas/landingPage.json";
+    private static String urlSchema="https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/landingPage.yaml";
 
     /**
      * <pre>
-     * cf. <a href="https://github.com/opengeospatial/ogcapi-processes/blob/master/core/abstract_tests/core/ATS_landingpage-success.adoc">core/abstract_tests/core/ATS_landingpage-success.adoc</a>
+     * cf. <a href="https://github.com/opengeospatial/ogcapi-processes/blob/master/core/abstract_tests/core/ATS_landingpage-op.adoc">core/abstract_tests/core/ATS_landingpage-op.adoc</a>
      * Abstract Test 1: /conf/core/landingpage-op
      * Test Purpose: Validate that a landing page can be retrieved from the expected location.
      * Requirement: /req/core/root-op
@@ -88,59 +94,28 @@ public class LandingPage extends CommonFixture {
 	    linkTypes.contains( required[0] ),
 	    linkTypes.contains( required[1] ),
 	};
+	// A.2.1.2.3.a Validate that the landing page includes a "service-desc" and/or "service-doc" link to an API Definition.
 	assertTrue( isValid[0] || isValid[1],
 		    "The landing page must include includes a 'service-desc' and/or 'service-doc' link to an API Definition, but contains "
 		    + String.join( ", ", linkTypes ) );
+	// A.2.1.2.3.b Validate that the landing page includes a "http://www.opengis.net/def/rel/ogc/1.0/conformance" link to the conformance class declaration.
+	// A.2.1.2.3.c Validate that the landing page includes a "http://www.opengis.net/def/rel/ogc/1.0/processes" link to the list of processes.
 	for(int i=2;i<required.length;i++){
 	    boolean expectedLinkTypesExists = linkTypes.contains( required[i] );
 	    assertTrue( expectedLinkTypesExists,
 			"The landing page must include at least links with relation type '"+required[i]+"', but contains "
 			+ String.join( ", ", linkTypes ) );
 	}
-	
-	/**
-	 * Should be JSON-SCHEMA validation
-	 * schema: https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/landingPage.yaml
-	 * schema instance (object): response
-	 * TODO: IsValid? (make this resuable once higer level will works)
-	 */
-	JsonFactory json_factory = new JsonFactory();
-	YAMLFactory yaml_factory = new YAMLFactory();
-	ObjectMapper objectMapper =new ObjectMapper();
-	ObjectMapper objMapper =new ObjectMapper(new YAMLFactory());
-	Response lrequest = init().baseUri( "https://raw.githubusercontent.com/" ).when().request( GET, "/opengeospatial/ogcapi-processes/master/core/openapi/schemas/link.yaml" );
-	lrequest.then().statusCode( 200 );
-	String lresponse = lrequest.getBody().asString();
-	JsonSchemaFactory factory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7)).objectMapper(objMapper).build();
-	SchemaValidatorsConfig config = new SchemaValidatorsConfig();
-	config.setTypeLoose(false);
-	try{
-	    JsonNode node = new ObjectMapper().readTree(yaml_factory.createParser(lresponse));
-	    System.out.println(node.toString());
-	    JsonSchema jsonSchema = factory.getSchema(IOUtils.toInputStream(node.toString()), config);
-	    JsonNode json = objectMapper.readTree(body);
-	    System.out.println(response.toString());
-	    JsonNode arrayNode = json.get("links");
-	    if (arrayNode.isArray()) {
-		for (JsonNode jsonNode : arrayNode) {
-		    System.out.println(jsonNode.toString());
-		    Set<ValidationMessage> validationResult = jsonSchema.validate(jsonNode);
-		    if (validationResult.isEmpty()) {
-			TestSuiteLogger.log(Level.INFO, "no validation errors :-)");
-			System.out.println("no validation errors :-)");
-		    } else {
-			validationResult.forEach(vm -> System.out.println(vm.getMessage()));
-		    }
-		}
-	    }
-	    System.out.println(json.toString());
-	} catch (Exception e) {
-	    e.printStackTrace();
-	    return;
-	}
+	// A.2.1.2.2 Validate the landing page for *all supported media types* (only JSON) using the resources and tests identified in Schema and Tests for Landing Pages
+	// /conf/(geojson?)json/content
+	assertTrue( validateResponseAgainstSchema(LandingPage.urlSchema,body),
+		    "The landing page does nto conform to the schema: "+LandingPage.urlSchema);
 
+	checkHtmlConfClass(rootUri.toString());
+	
     }
 
+	
     private Set<String> collectLinkTypes( List<Object> links ) {
         Set<String> linkTypes = new HashSet<>();
         for ( Object link : links ) {

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage.java
@@ -3,6 +3,21 @@ package org.opengis.cite.ogcapiprocesses10.landingpage;
 import static io.restassured.http.ContentType.JSON;
 import static io.restassured.http.Method.GET;
 import static org.opengis.cite.ogcapiprocesses10.EtsAssert.assertTrue;
+//import com.atlassian.oai.validator.OpenApiInteractionValidator;
+//import com.atlassian.oai.validator.report.ValidationReport;
+import com.networknt.schema.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.core.JsonFactory;
+
+import io.swagger.v3.parser.*;
+import io.swagger.parser.*;
+import io.swagger.v3.parser.*;
+import io.swagger.v3.parser.core.models.*;
+import io.swagger.v3.oas.models.*;
+
+import org.apache.commons.io.IOUtils;
 
 import java.util.HashSet;
 import java.util.List;
@@ -26,11 +41,12 @@ import io.restassured.response.Response;
 public class LandingPage extends CommonFixture {
 
     private JsonPath response;
+    private String body;
 
 
     /**
      * <pre>
-     * cf. core/abstract_tests/core/ATS_landingpage-success.adoc
+     * cf. <a href="https://github.com/opengeospatial/ogcapi-processes/blob/master/core/abstract_tests/core/ATS_landingpage-success.adoc">core/abstract_tests/core/ATS_landingpage-success.adoc</a>
      * Abstract Test 1: /conf/core/landingpage-op
      * Test Purpose: Validate that a landing page can be retrieved from the expected location.
      * Requirement: /req/core/root-op
@@ -41,20 +57,21 @@ public class LandingPage extends CommonFixture {
      *  3. Validate the contents of the returned document using test /conf/core/landingpage-success.
      * </pre>
      */
-    @Test(description = "Implements Abstract Test 1: /conf/core/landingpage-op", groups = "landingpage")
+    @Test(description = "Implements Abstract Test 1: /conf/core/landingpage-op", groups = "A.2.1. Landing Page /")
     public void landingPageRetrieval() {
         Response request = init().baseUri( rootUri.toString() ).accept( JSON ).when().request( GET, "/" );
         TestSuiteLogger.log(Level.INFO, rootUri.toString());
         request.then().statusCode( 200 );
         response = request.jsonPath();
+	body = request.getBody().asString();
     }
 
     /**
      * <pre>
-     * cf. core/abstract_tests/core/ATS_landingpage-success.adoc
+     * cf. <a href="https://github.com/opengeospatial/ogcapi-processes/blob/master/core/abstract_tests/core/ATS_landingpage-success.adoc">core/abstract_tests/core/ATS_landingpage-success.adoc</a>
      * </pre>
      */
-    @Test(description = "Implements Abstract Test 2: /conf/core/landingpage-success", groups = "landingpage")
+    @Test(description = "Implements Abstract Test 2: /conf/core/landingpage-success", groups = "A.2.1. Landing Page /")
     public void landingPageValidation() {
 
         List<Object> links = response.getList( "links" );
@@ -67,12 +84,59 @@ public class LandingPage extends CommonFixture {
 	    "http://www.opengis.net/def/rel/ogc/1.0/conformance",
 	    "http://www.opengis.net/def/rel/ogc/1.0/processes"
 	};
-	
-	for(int i=0;i<required.length;i++){
+	boolean isValid[] = {
+	    linkTypes.contains( required[0] ),
+	    linkTypes.contains( required[1] ),
+	};
+	assertTrue( isValid[0] || isValid[1],
+		    "The landing page must include includes a 'service-desc' and/or 'service-doc' link to an API Definition, but contains "
+		    + String.join( ", ", linkTypes ) );
+	for(int i=2;i<required.length;i++){
 	    boolean expectedLinkTypesExists = linkTypes.contains( required[i] );
 	    assertTrue( expectedLinkTypesExists,
 			"The landing page must include at least links with relation type '"+required[i]+"', but contains "
 			+ String.join( ", ", linkTypes ) );
+	}
+	
+	/**
+	 * Should be JSON-SCHEMA validation
+	 * schema: https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/landingPage.yaml
+	 * schema instance (object): response
+	 * TODO: IsValid? (make this resuable once higer level will works)
+	 */
+	JsonFactory json_factory = new JsonFactory();
+	YAMLFactory yaml_factory = new YAMLFactory();
+	ObjectMapper objectMapper =new ObjectMapper();
+	ObjectMapper objMapper =new ObjectMapper(new YAMLFactory());
+	Response lrequest = init().baseUri( "https://raw.githubusercontent.com/" ).when().request( GET, "/opengeospatial/ogcapi-processes/master/core/openapi/schemas/link.yaml" );
+	lrequest.then().statusCode( 200 );
+	String lresponse = lrequest.getBody().asString();
+	JsonSchemaFactory factory = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7)).objectMapper(objMapper).build();
+	SchemaValidatorsConfig config = new SchemaValidatorsConfig();
+	config.setTypeLoose(false);
+	try{
+	    JsonNode node = new ObjectMapper().readTree(yaml_factory.createParser(lresponse));
+	    System.out.println(node.toString());
+	    JsonSchema jsonSchema = factory.getSchema(IOUtils.toInputStream(node.toString()), config);
+	    JsonNode json = objectMapper.readTree(body);
+	    System.out.println(response.toString());
+	    JsonNode arrayNode = json.get("links");
+	    if (arrayNode.isArray()) {
+		for (JsonNode jsonNode : arrayNode) {
+		    System.out.println(jsonNode.toString());
+		    Set<ValidationMessage> validationResult = jsonSchema.validate(jsonNode);
+		    if (validationResult.isEmpty()) {
+			TestSuiteLogger.log(Level.INFO, "no validation errors :-)");
+			System.out.println("no validation errors :-)");
+		    } else {
+			validationResult.forEach(vm -> System.out.println(vm.getMessage()));
+		    }
+		}
+	    }
+	    System.out.println(json.toString());
+	} catch (Exception e) {
+	    e.printStackTrace();
+	    return;
 	}
 
     }

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage.java
@@ -19,28 +19,29 @@ import io.restassured.response.Response;
 
 /**
  *
- * A.2.2. Landing Page {root}/
+ * A.2.1. Landing Page {root}/
  *
  * @author <a href="mailto:goltz@lat-lon.de">Lyn Goltz </a>
  */
 public class LandingPage extends CommonFixture {
 
-	private JsonPath response;
+    private JsonPath response;
 
 
     /**
      * <pre>
-     * Abstract Test 3: /ats/core/root-op
+     * cf. core/abstract_tests/core/ATS_landingpage-success.adoc
+     * Abstract Test 1: /conf/core/landingpage-op
      * Test Purpose: Validate that a landing page can be retrieved from the expected location.
      * Requirement: /req/core/root-op
      *
      * Test Method:
      *  1. Issue an HTTP GET request to the URL {root}/
      *  2. Validate that a document was returned with a status code 200
-     *  3. Validate the contents of the returned document using test /ats/core/root-success.
+     *  3. Validate the contents of the returned document using test /conf/core/landingpage-success.
      * </pre>
      */
-    @Test(description = "Implements Requirement TBA", groups = "landingpage")
+    @Test(description = "Implements Abstract Test 1: /conf/core/landingpage-op", groups = "landingpage")
     public void landingPageRetrieval() {
         Response request = init().baseUri( rootUri.toString() ).accept( JSON ).when().request( GET, "/" );
         TestSuiteLogger.log(Level.INFO, rootUri.toString());
@@ -50,21 +51,29 @@ public class LandingPage extends CommonFixture {
 
     /**
      * <pre>
-     * Requirement TBA  
+     * cf. core/abstract_tests/core/ATS_landingpage-success.adoc
      * </pre>
      */
-    @Test(description = "Implements Requirement TBA: Landing Page ", groups = "landingpage")
+    @Test(description = "Implements Abstract Test 2: /conf/core/landingpage-success", groups = "landingpage")
     public void landingPageValidation() {
 
         List<Object> links = response.getList( "links" );
 
         Set<String> linkTypes = collectLinkTypes( links );
 
-        boolean expectedLinkTypesExists = linkTypes.contains( "processes" );
-        assertTrue( expectedLinkTypesExists,
-                    "The landing page must include at least links with relation type 'processes', but contains "
-                                             + String.join( ", ", linkTypes ) );
-
+	String required[] = {
+	    "service-desc",
+	    "service-doc",
+	    "http://www.opengis.net/def/rel/ogc/1.0/conformance",
+	    "http://www.opengis.net/def/rel/ogc/1.0/processes"
+	};
+	
+	for(int i=0;i<required.length;i++){
+	    boolean expectedLinkTypesExists = linkTypes.contains( required[i] );
+	    assertTrue( expectedLinkTypesExists,
+			"The landing page must include at least links with relation type '"+required[i]+"', but contains "
+			+ String.join( ", ", linkTypes ) );
+	}
 
     }
 

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage.java
@@ -47,8 +47,9 @@ public class LandingPage extends CommonFixture {
     private JsonPath response;
     private String body;
     
-    //private static String utrlSchema="http://beta.schemas.opengis.net/ogcapi/common/part1/0.1/core/openapi/schemas/landingPage.json";
-    private static String urlSchema="https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/landingPage.yaml";
+    //private static String utrlSchema="http://schemas.opengis.net/ogcapi/common/part1/0.1/core/openapi/schemas/landingPage.json";
+    //private static String urlSchema="https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/landingPage.yaml";
+    private static String urlSchema="http://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/landingPage.yaml";
 
     /**
      * <pre>

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/process/Process.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/process/Process.java
@@ -48,150 +48,164 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class Process extends CommonFixture {
 
-	private static final String OPERATION_ID_GET_PROCESS_DESCRIPTION = "getProcessDescription";
+    private static final String OPERATION_ID_GET_PROCESS_DESCRIPTION = "getProcessDescription";
 
-	private OpenApi3 openApi3;
+    private OpenApi3 openApi3;
 	
-	private String getProcessListPath = "/processes";
+    private String getProcessListPath = "/processes";
 	
-	private OperationValidator getProcessDescriptionValidator;
+    private OperationValidator getProcessDescriptionValidator;
     
     private URL getInvalidProcessURL;
     
     private String echoProcessId;
 
-	private String echoProcessPath;
+    private String echoProcessPath;
     
-	@BeforeClass
-	public void setup(ITestContext testContext) {		
-		String processListEndpointString = rootUri.toString() + getProcessListPath;		
-		try {
-			openApi3 = new OpenApi3Parser().parse(specURI.toURL(), false);
-			addServerUnderTest(openApi3);
-		    final Path path = openApi3.getPathItemByOperationId(OPERATION_ID_GET_PROCESS_DESCRIPTION);
-		    final Operation operation = openApi3.getOperationById(OPERATION_ID_GET_PROCESS_DESCRIPTION);
-		    getProcessDescriptionValidator = new OperationValidator(openApi3, path, operation);
-		    getInvalidProcessURL = new URL(processListEndpointString + "/invalid-process-" + UUID.randomUUID());
-		} catch (MalformedURLException | ResolutionException | ValidationException e) {
-			Assert.fail("Could set up endpoint: " + processListEndpointString + ". Exception: " + e.getLocalizedMessage());
-		}
-		echoProcessId = (String) testContext.getSuite().getAttribute( SuiteAttribute.ECHO_PROCESS_ID.getName() );
-	    echoProcessPath = getProcessListPath + "/" + echoProcessId;
+    @BeforeClass
+    public void setup(ITestContext testContext) {		
+	String processListEndpointString = rootUri.toString() + getProcessListPath;		
+	try {
+	    openApi3 = new OpenApi3Parser().parse(specURI.toURL(), false);
+	    addServerUnderTest(openApi3);
+	    final Path path = openApi3.getPathItemByOperationId(OPERATION_ID_GET_PROCESS_DESCRIPTION);
+	    final Operation operation = openApi3.getOperationById(OPERATION_ID_GET_PROCESS_DESCRIPTION);
+	    getProcessDescriptionValidator = new OperationValidator(openApi3, path, operation);
+	    getInvalidProcessURL = new URL(processListEndpointString + "/invalid-process-" + UUID.randomUUID());
+	} catch (MalformedURLException | ResolutionException | ValidationException e) {
+	    Assert.fail("Could set up endpoint: " + processListEndpointString + ". Exception: " + e.getLocalizedMessage());
 	}
+	echoProcessId = (String) testContext.getSuite().getAttribute( SuiteAttribute.ECHO_PROCESS_ID.getName() );
+	echoProcessPath = getProcessListPath + "/" + echoProcessId;
+    }
 	
-	/**
-	* <pre>
-	* Abstract Test 15: /conf/core/process-exception-no-such-process
-	* Test Purpose: Validate that an invalid process identifier is handled correctly.
-	* Requirement: /req/core/process-exception-no-such-process
-	* Test Method: 
-	* 1.  Validate that the document contains the exception `type` "http://wwwopengisnet/def/exceptions/ogcapi-processes-1/10/no-such-process"
-	* 2.  Validate the document for all supported media types using the resources and tests identified in no-such-process
-	* |===
-	* 
-	* An exception response caused by the use of an invalid process identifier may be retrieved in a number of different formats. The following table identifies the applicable schema document for each format and the test to be used to validate the response. All supported formats should be exercised.
-	* 
-	* [[no-such-process]]
-	* 3. Schema and Tests for Non-existent Process
-	* [width="90%",cols="3",options="header"]
-	* |===
-	* |Format |Schema Document |Test ID
-	* |HTML |link:http://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/exception.yaml[exception.yaml] |ats_html_content,/conf/html/content
-	* |JSON |link:http://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/exception.yaml[exception.yaml] |ats_json_content,/conf/json/content
-	* |===
-	* TODO: Check additional content
-	* </pre>
-	*/
-	@Test(description = "Implements Requirement /req/core/process-exception-no-such-process ", groups = "process")
-	public void testProcessExceptionNoSuchProcess() {
-		final ValidationData<Void> data = new ValidationData<>();
-		try {
-			HttpClient client = HttpClientBuilder.create().build();
-			HttpUriRequest request = new HttpGet(getInvalidProcessURL.toString());
-			request.setHeader("Accept", "application/json");
-			HttpResponse httpResponse = client.execute(request);
-			StringWriter writer = new StringWriter();
-			String encoding = StandardCharsets.UTF_8.name();
-			IOUtils.copy(httpResponse.getEntity().getContent(), writer, encoding);
-			JsonNode responseNode = new ObjectMapper().readTree(writer.toString());
-			Body body = Body.from(responseNode);
-			Header contentType = httpResponse.getFirstHeader(CONTENT_TYPE);
-			Response response = new DefaultResponse.Builder(httpResponse.getStatusLine().getStatusCode()).body(body).header(CONTENT_TYPE, contentType.getValue())
-					.build();
-			getProcessDescriptionValidator.validateResponse(response, data);
-			Assert.assertTrue(data.isValid(), printResults(data.results()));
-		} catch (Exception e) {
-			e.printStackTrace();
-			Assert.fail(e.getLocalizedMessage());
-		}
+    /**
+     * <pre>
+     * Abstract Test 15: /conf/core/process-exception-no-such-process
+     * Test Purpose: Validate that an invalid process identifier is handled correctly.
+     * Requirement: /req/core/process-exception-no-such-process
+     * Test Method: 
+     * 1.  Validate that the document contains the exception `type` "http://wwwopengisnet/def/exceptions/ogcapi-processes-1/10/no-such-process"
+     * 2.  Validate the document for all supported media types using the resources and tests identified in no-such-process
+     * |===
+     * 
+     * An exception response caused by the use of an invalid process identifier may be retrieved in a number of different formats. The following table identifies the applicable schema document for each format and the test to be used to validate the response. All supported formats should be exercised.
+     * 
+     * [[no-such-process]]
+     * 3. Schema and Tests for Non-existent Process
+     * [width="90%",cols="3",options="header"]
+     * |===
+     * |Format |Schema Document |Test ID
+     * |HTML |link:http://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/exception.yaml[exception.yaml] |ats_html_content,/conf/html/content
+     * |JSON |link:http://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/exception.yaml[exception.yaml] |ats_json_content,/conf/json/content
+     * |===
+     * TODO: Check additional content
+     * </pre>
+     */
+    @Test(description = "Implements Requirement /req/core/process-exception-no-such-process ", groups = "process")
+    public void testProcessExceptionNoSuchProcess() {
+	final ValidationData<Void> data = new ValidationData<>();
+	try {
+	    HttpClient client = HttpClientBuilder.create().build();
+	    HttpUriRequest request = new HttpGet(getInvalidProcessURL.toString());
+	    request.setHeader("Accept", "application/json");
+	    HttpResponse httpResponse = client.execute(request);
+	    StringWriter writer = new StringWriter();
+	    String encoding = StandardCharsets.UTF_8.name();
+	    IOUtils.copy(httpResponse.getEntity().getContent(), writer, encoding);
+	    JsonNode responseNode = new ObjectMapper().readTree(writer.toString());
+	    Body body = Body.from(responseNode);
+	    Header contentType = httpResponse.getFirstHeader(CONTENT_TYPE);
+	    Response response = new DefaultResponse.Builder(httpResponse.getStatusLine().getStatusCode()).body(body).header(CONTENT_TYPE, contentType.getValue())
+		.build();
+	    getProcessDescriptionValidator.validateResponse(response, data);
+	    Assert.assertTrue(data.isValid(), printResults(data.results()));
+	} catch (Exception e) {
+	    e.printStackTrace();
+	    Assert.fail(e.getLocalizedMessage());
+	}
+    }
+
+    /**
+     * <pre>
+     * Abstract Test 13: /conf/core/process
+     * Test Purpose: Validate that a process description can be retrieved from the expected location.
+     * Requirement: /req/core/process
+     * Test Method: 
+     * |===
+     * TODO: Check additional content
+     * </pre>
+     */
+    @Test(description = "Implements Requirement /req/core/process ", groups = "process")
+    public void testProcess() {
+	final ValidationData<Void> data = new ValidationData<>();
+	try {
+	    //Request request = new PathSettingRequest(rootUri.toString(), echoProcessPath, Request.Method.GET);
+	    //getProcessDescriptionValidator.validatePath(request, data);
+
+	    HttpClient client = HttpClientBuilder.create().build();
+	    HttpUriRequest request = new HttpGet(rootUri.toString()+echoProcessPath);
+	    request.setHeader("Accept", "application/json");
+	    HttpResponse httpResponse = client.execute(request);
+	    StringWriter writer = new StringWriter();
+	    String encoding = StandardCharsets.UTF_8.name();
+	    IOUtils.copy(httpResponse.getEntity().getContent(), writer, encoding);
+	    JsonNode responseNode = new ObjectMapper().readTree(writer.toString());
+	    Body body = Body.from(responseNode);
+	    Header contentType = httpResponse.getFirstHeader(CONTENT_TYPE);
+	    Response response = new DefaultResponse.Builder(httpResponse.getStatusLine().getStatusCode()).body(body).header(CONTENT_TYPE, contentType.getValue())
+		.build();
+	    getProcessDescriptionValidator.validateResponse(response, data);
+	    Assert.assertTrue(data.isValid(), printResults(data.results()));
+	} catch (Exception e) {
+	    e.printStackTrace();
+	    Assert.fail("Could not validate path: " + echoProcessPath + "\n" + printResults(data.results()));
+	}
+    }
+
+    /**
+     * <pre>
+     * Abstract Test 14: /conf/core/process-success
+     * Test Purpose: Validate that the content complies with the required structure and contents.
+     * Requirement: /req/core/process-success
+     * Test Method: 
+     * |===
+     * 
+     * The interface of a process may be describing using a number of different models or process description languages. The following table identifies the applicable schema document for each process description model described in this standard.
+     * 
+     * [[process-description-model]]
+     * 1. Schema and Tests for Process Description Models
+     * [width="90%",cols="3",options="header"]
+     * |===
+     * |Model |Schema Document |Test ID
+     * |OGC Process Description JSON|link:http://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/process.yaml[process.yaml] |req_ogc-process-description_json-encoding,/conf/ogc-process-description/json-encoding
+     * |===
+     * TODO: Check additional content
+     * </pre>
+     */
+    @Test(description = "Implements Requirement /req/core/process-success ", groups = "process")
+    public void testProcessSuccess() {
+	final ValidationData<Void> data = new ValidationData<>();
+	try {
+	    HttpClient client = HttpClientBuilder.create().build();
+	    HttpUriRequest request = new HttpGet(rootUri + echoProcessPath);
+	    request.setHeader("Accept", "application/json");
+	    HttpResponse httpResponse = client.execute(request);
+	    StringWriter writer = new StringWriter();
+	    String encoding = StandardCharsets.UTF_8.name();
+	    IOUtils.copy(httpResponse.getEntity().getContent(), writer, encoding);
+	    JsonNode responseNode = new ObjectMapper().readTree(writer.toString());
+	    Body body = Body.from(responseNode);
+	    Header contentType = httpResponse.getFirstHeader(CONTENT_TYPE);
+	    Response response = new DefaultResponse.Builder(httpResponse.getStatusLine().getStatusCode()).body(body).header(CONTENT_TYPE, contentType.getValue())
+		.build();
+	    getProcessDescriptionValidator.validateResponse(response, data);
+	    Assert.assertTrue(data.isValid(), printResults(data.results()));
+	} catch (Exception e) {
+	    Assert.fail(e.getLocalizedMessage());
 	}
 
-	/**
-	* <pre>
-	* Abstract Test 13: /conf/core/process
-	* Test Purpose: Validate that a process description can be retrieved from the expected location.
-	* Requirement: /req/core/process
-	* Test Method: 
-	* |===
-	* TODO: Check additional content
-	* </pre>
-	*/
-	@Test(description = "Implements Requirement /req/core/process ", groups = "process")
-	public void testProcess() {
-	    final ValidationData<Void> data = new ValidationData<>();
-	    try {
-			Request request = new PathSettingRequest(rootUri.toString(), echoProcessPath, Request.Method.GET);
-			getProcessDescriptionValidator.validatePath(request, data);
-		} catch (Exception e) {
-			e.printStackTrace();
-			Assert.fail("Could not validate path: " + echoProcessPath + "\n" + printResults(data.results()));
-		}
-		Assert.assertTrue(data.isValid(), printResults(data.results()));
-	}
-
-	/**
-	* <pre>
-	* Abstract Test 14: /conf/core/process-success
-	* Test Purpose: Validate that the content complies with the required structure and contents.
-	* Requirement: /req/core/process-success
-	* Test Method: 
-	* |===
-	* 
-	* The interface of a process may be describing using a number of different models or process description languages. The following table identifies the applicable schema document for each process description model described in this standard.
-	* 
-	* [[process-description-model]]
-	* 1. Schema and Tests for Process Description Models
-	* [width="90%",cols="3",options="header"]
-	* |===
-	* |Model |Schema Document |Test ID
-	* |OGC Process Description JSON|link:http://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/process.yaml[process.yaml] |req_ogc-process-description_json-encoding,/conf/ogc-process-description/json-encoding
-	* |===
-	* TODO: Check additional content
-	* </pre>
-	*/
-	@Test(description = "Implements Requirement /req/core/process-success ", groups = "process")
-	public void testProcessSuccess() {
-		final ValidationData<Void> data = new ValidationData<>();
-		try {
-			HttpClient client = HttpClientBuilder.create().build();
-			HttpUriRequest request = new HttpGet(rootUri + echoProcessPath);
-			request.setHeader("Accept", "application/json");
-			HttpResponse httpResponse = client.execute(request);
-			StringWriter writer = new StringWriter();
-			String encoding = StandardCharsets.UTF_8.name();
-			IOUtils.copy(httpResponse.getEntity().getContent(), writer, encoding);
-			JsonNode responseNode = new ObjectMapper().readTree(writer.toString());
-			Body body = Body.from(responseNode);
-			Header contentType = httpResponse.getFirstHeader(CONTENT_TYPE);
-			Response response = new DefaultResponse.Builder(httpResponse.getStatusLine().getStatusCode()).body(body).header(CONTENT_TYPE, contentType.getValue())
-					.build();
-			getProcessDescriptionValidator.validateResponse(response, data);
-			Assert.assertTrue(data.isValid(), printResults(data.results()));
-		} catch (Exception e) {
-			Assert.fail(e.getLocalizedMessage());
-		}
-
-	}
+    }
 
 
 }


### PR DESCRIPTION
In this pull request we added a Dockerfile that one can use to to deploy the TEAMEngine locally without having to setup any JAVA environment.

We also included a tentative implementation for testing responses against json-schema: `validateResponseAgainstSchema`. Note that the schema are accessed remotely from the official OGC schemas repository (http://schemas.opengis.net/ogcapi/processes/part1/1.0/). We left the comment to the URL used initially relying on the GitHub repository.

The `validateResponseAgainstSchema` method is used from `Conformance.java` and LandingPage.java only by now.

We also slightly updated the Conformance class to make sure that the following tests are partly handled: A.2.1.2.3.a, A.2.1.2.3.b and A.2.1.2.3.c.

