### PR TITLE
Fix issue #6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.1.0</version>
+      <version>3.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.reprezen.kaizen</groupId>
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.7</version>
+      <version>3.4</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,11 +77,6 @@
       <version>4.0.4</version>
     </dependency>
     <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>4.0</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
@@ -89,12 +84,13 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
-	<dependency>
-		<groupId>org.openapi4j</groupId>
-		<artifactId>openapi-operation-validator</artifactId>
-		<version>1.0.7</version>
-	</dependency>
 
+    <dependency>
+      <groupId>org.openapi4j</groupId>
+      <artifactId>openapi-operation-validator</artifactId>
+      <version>1.0.7</version>
+    </dependency>
+    
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
@@ -105,15 +101,17 @@
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>2.10.1</version>
     </dependency>
+    <!--
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser</artifactId>
       <version>2.0.28</version>
     </dependency>
+    -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
+      <version>1.7.20</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -121,9 +119,14 @@
       <version>3.7</version>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.7</version>
+    </dependency>
+    <dependency>
       <groupId>com.networknt</groupId>
       <artifactId>json-schema-validator</artifactId>
-      <version>1.0.63</version>
+      <version>1.0.66</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/landingpage/LandingPage.java
@@ -15,13 +15,7 @@ import java.util.HashMap;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.URI;
 
-import io.swagger.v3.parser.*;
-import io.swagger.parser.*;
-import io.swagger.v3.parser.*;
-import io.swagger.v3.parser.core.models.*;
-import io.swagger.v3.oas.models.*;
-
-import org.apache.commons.io.IOUtils;
+//import org.apache.commons.io.IOUtils;
 
 import java.util.HashSet;
 import java.util.List;


### PR DESCRIPTION
Following @dstenger insights from the issue #6, I updated the dependencies version to be the same in both [ets-ogcapi-features10](https://github.com/opengeospatial/ets-ogcapi-features10/blob/master/pom.xml) and in [ets-ogcapi-processes10](https://github.com/opengeospatial/ets-ogcapi-processes10/blob/master/pom.xml).

This does apply to few dependencies listed bellow:
* `io.rest-assured` / `rest-assured` (version 3.3.0)
* `com.reprezen.kaizen` / `openapi-parser` (version 4.0.4)
* `org.apache.commons` / `commons-lang3` (version 3.4)

