### PR TITLE
all in one docker build call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,13 +34,17 @@ FROM maven:3.8.3-jdk-8-slim AS build
 ARG BUILD_DEPS=" \
     git \
 "
-COPY src /home/app/src
-COPY src1 /home/app/src1
+WORKDIR /home/app
+COPY src/ /home/app/ets-ogcapi-processes10/src/
+COPY pom.xml /home/app/ets-ogcapi-processes10
 RUN apt-get update && \
     apt-get install -y $BUILD_DEPS && \
     echo "teamengine building..." && \
-    mvn -f /home/app/src/pom.xml clean install > log && \
-    mvn -f /home/app/src1/ets-ogcapi-processes10/pom.xml clean install && \
+    git clone --depth 1 https://github.com/opengeospatial/ets-common.git && \
+    git clone --depth 1 https://github.com/opengeospatial/teamengine && \
+    mvn -f /home/app/teamengine/pom.xml clean install > log && \
+    mvn -f /home/app/ets-common/pom.xml clean install > log && \
+    mvn -f /home/app/ets-ogcapi-processes10/pom.xml clean install && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $BUILD_DEPS && \
     rm -rf /var/lib/apt/lists/*
 
@@ -51,11 +55,11 @@ FROM tomcat:7.0-jre8
 ARG BUILD_DEPS=" \
     unzip \
 "
-COPY --from=build /home/app/src/teamengine-web/target/teamengine*.war /root
-COPY --from=build /home/app/src/teamengine-web/target/teamengine-*common-libs.zip /root
-COPY --from=build /home/app/src/teamengine-console/target/teamengine-console-*-base.zip /root
-COPY --from=build /home/app/src1/ets-ogcapi-processes10/target/ets-ogcapi-processes10-*-ctl.zip /root
-COPY --from=build /home/app/src1/ets-ogcapi-processes10/target/ets-ogcapi-processes10-*-deps.zip /root
+COPY --from=build /home/app/teamengine/teamengine-web/target/teamengine*.war /root
+COPY --from=build /home/app/teamengine/teamengine-web/target/teamengine-*common-libs.zip /root
+COPY --from=build /home/app/teamengine/teamengine-console/target/teamengine-console-*-base.zip /root
+COPY --from=build /home/app/ets-ogcapi-processes10/target/ets-ogcapi-processes10-*-ctl.zip /root
+COPY --from=build /home/app/ets-ogcapi-processes10/target/ets-ogcapi-processes10-*-deps.zip /root
 ENV JAVA_OPTS="-Xms1024m -Xmx2048m -DTE_BASE=/root/te_base"
 RUN cd /root && \
     mkdir te_base && \

--- a/README.adoc
+++ b/README.adoc
@@ -12,16 +12,14 @@ for more information, including the API documentation.
 Run the following commands:
 
 [source,bash]
-mkdir CITE
-cd CITE
-git clone https://github.com/opengeospatial/teamengine src
-git clone https://github.com/opengeospatial/ets-common.git src1
-cd src1
-git clone -b testbed17 https://github.com/GeoLabs/ets-ogcapi-processes10.git
-cd ..
+# Clone this repository
+git clone https://github.com/opengeospatial/ets-ogcapi-processes10
+cd ets-ogcapi-processes10
+
 # Build the docker image
 docker build . -t teamengine/ogcapi-processes:latest
-# Run the docker container 
+
+# Run the docker container
 docker run -d --name cite-teamengine -p 8080:8080 teamengine/ogcapi-processes:latest
 
 From here, you can now access http://localhost:8080/teamengine to access the deployed teamengine with the OGC API - Processes Test Suite.

--- a/README.adoc
+++ b/README.adoc
@@ -12,6 +12,7 @@ for more information, including the API documentation.
 Run the following commands:
 
 [source,bash]
+....
 # Clone this repository
 git clone https://github.com/opengeospatial/ets-ogcapi-processes10
 cd ets-ogcapi-processes10
@@ -21,6 +22,7 @@ docker build . -t teamengine/ogcapi-processes:latest
 
 # Run the docker container
 docker run -d --name cite-teamengine -p 8080:8080 teamengine/ogcapi-processes:latest
+....
 
 From here, you can now access http://localhost:8080/teamengine to access the deployed teamengine with the OGC API - Processes Test Suite.
 


### PR DESCRIPTION
I would like to propose this alternative Dockerfile. 

The user that wants to use the test suite shouldn't need to clone all dependencies as listed in the README. 

Fixes #24
