### PR TITLE
Updates proposal for OGCProcessDescription and Jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@
 #  1. build the teamengine
 #  2. build the Test Suite
 #
-FROM maven:3.8.3-jdk-8-slim AS build
+#FROM maven:3.8.3-jdk-8-slim AS build
+FROM maven:3.8.6-jdk-8-slim AS build
 ARG BUILD_DEPS=" \
     git \
 "

--- a/src/main/config/test-run-props.xml
+++ b/src/main/config/test-run-props.xml
@@ -2,7 +2,8 @@
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties version="1.0">
   <comment>Sample test run arguments (ets-ogcapi-processes10)</comment>
-  <entry key="iut">http://tb17.geolabs.fr:8101/ogc-api</entry>
-<!--   <entry key="iut">http://geoprocessing.demo.52north.org:8080/javaps/rest/</entry> -->
+  <entry key="iut">http://tb17.geolabs.fr:8111/ogc-api</entry>
   <entry key="echoprocessid">echo</entry>
+  <entry key="testAllProcesses">false</entry>
+  <entry key="processTestLimit">3</entry>
 </properties>

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/CommonFixture.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/CommonFixture.java
@@ -13,7 +13,11 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpResponse;
 import org.apache.http.HttpRequest;
 import org.openapi4j.core.validation.ValidationResults;
 import org.openapi4j.core.validation.ValidationResults.ValidationItem;
@@ -21,6 +25,7 @@ import org.openapi4j.parser.model.v3.OpenApi3;
 import org.openapi4j.parser.model.v3.Server;
 import org.testng.ITestContext;
 import org.testng.ITestResult;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -89,10 +94,13 @@ public class CommonFixture {
         limit = (Integer) testContext.getSuite().getAttribute( SuiteAttribute.PROCESS_TEST_LIMIT.getName() );
         testAllProcesses = (Boolean) testContext.getSuite().getAttribute( SuiteAttribute.TEST_ALL_PROCESSES.getName() );
         try {
-			specURI = new URI("https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/openapi.yaml");
-		} catch (URISyntaxException e) {
-			e.printStackTrace();
-		}
+	    //specURI = new URI("https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/openapi.yaml");
+	    //specURI = new URI("https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/ogcapi-processes-1.yaml");
+	    //specURI = new URI("https://raw.githubusercontent.com/GeoLabs/ogcapi-processes/fix-failed-loading-openapi/openapi/ogcapi-processes.yaml");
+	    specURI = new URI("https://raw.githubusercontent.com/GeoLabs/ogcapi-processes/fix-failed-loading-openapi/openapi.yaml");
+	} catch (URISyntaxException e) {
+	    e.printStackTrace();
+	}
     }
 
     @BeforeMethod
@@ -180,6 +188,19 @@ public class CommonFixture {
 				     + headerValue
 				     + "' has been found" );
 	String bodyHTML = request.getBody().asString();
+    }
+
+    protected JsonNode parseJsonResponse(HttpResponse httpResponse){
+	try{
+	    StringWriter writer = new StringWriter();
+	    String encoding = StandardCharsets.UTF_8.name();
+	    IOUtils.copy(httpResponse.getEntity().getContent(), writer, encoding);
+	    JsonNode responseNode = new ObjectMapper().readTree(writer.toString());
+	    return responseNode;
+	} catch(Exception e){
+	    Assert.fail("Could not parse the response. Exception: " + e.getLocalizedMessage());
+	    return null;
+	}
     }
 
     

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/OgcApiProcesses10.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/OgcApiProcesses10.java
@@ -14,4 +14,6 @@ public class OgcApiProcesses10 {
 
     public static final String GEOJSON_MIME_TYPE = "application/geo+json";
 
+    public static final String PROBLEM_MIME_TYPE = "application/problem+json";
+
 }

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/processlist/ProcessList.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/processlist/ProcessList.java
@@ -63,7 +63,7 @@ public class ProcessList extends CommonFixture {
 		    validator = new OperationValidator(openApi3, path, operation);
 		    getProcessListURL = new URL(processListEndpointString);
 		} catch (MalformedURLException | ResolutionException | ValidationException e) {
-			Assert.fail("Could set up endpoint: " + processListEndpointString + ". Exception: " + e.getLocalizedMessage());
+			Assert.fail("Could not set up endpoint: " + processListEndpointString + ". Exception: " + e.getLocalizedMessage());
 		}
 	}
 


### PR DESCRIPTION
This PR contains the work-around proposed here: https://github.com/opengeospatial/ets-ogcapi-processes10/issues/11#issuecomment-1402323261.

The modifications includes fixes for the following tests:

 * /conf/ogc-process-description/json-encoding
 * /conf/core/job-results-async-raw-value-one

The modification also introduces fix tentatives for the following tests:

 * /conf/ogc-process-description/inputs-def
 * /conf/ogc-process-description/input-def
 * /conf/ogc-process-description/input-mixed-type
 * /conf/ogc-process-description/outputs-def
 * /conf/ogc-process-description/output-def

Still have to review 3 tests on the ZOO-Kernel side (currently failing due to the fact that no Prefer header or response parameter was set and the default response should be document, despite what can be found in the [execute schema](https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/execute.yaml)): 

 * /conf/core/job-results-sync
 * /conf/core/job-creation-input-ref
 * /conf/core/job-creation-input-validation

Have to review this last test (don’t know yet on which side):

 * /conf/core/job-results
