### PR TITLE
Use getStatusValidator to validate

### DIFF
--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/jobs/Jobs.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/jobs/Jobs.java
@@ -1929,7 +1929,7 @@ public class Jobs extends CommonFixture {
 				throw new SkipException("Did not find Link Header with value rel=monitor, skipping test.");
 			}
 			httpResponse = sendGetRequest(statusUrl, ContentType.APPLICATION_JSON.getMimeType());
-			validateResponse(httpResponse, getResultValidator, data);
+			validateResponse(httpResponse, getStatusValidator, data);
 		} catch (IOException e) {
 			Assert.fail(e.getLocalizedMessage());
 		}


### PR DESCRIPTION
To validate against statusInfo.yaml schema, the getStatusValidator should be used in place of the getResultValidator. This last, may be used later on to fetch the result for example.