### PR TITLE
Feature fix loop over status

### DIFF
--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/jobs/Jobs.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/jobs/Jobs.java
@@ -2450,7 +2450,8 @@ public class Jobs extends CommonFixture {
 				}
 			// if the code gets to this position, no result or monitor link were found
 			// imho we need to throw an exception
-			throw new AssertionError(
+			if (!hasMonitorOrResultLink)
+				throw new AssertionError(
 					"No result (rel='http://www.opengis.net/def/rel/ogc/1.0/results') or monitor (rel='monitor') links were found in response.");
 
 		}

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/jobs/Jobs.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/jobs/Jobs.java
@@ -2407,8 +2407,19 @@ public class Jobs extends CommonFixture {
 			HttpClient client = HttpClientBuilder.create().build();
 			ArrayNode linksArrayNode = (ArrayNode) responseNode.get("links");
 
+			JsonNode statusNode = responseNode.get("status");
+
+			if (statusNode != null) {
+				String statusNodeText = statusNode.asText();
+				if (statusNodeText.equals("failed")) {
+					throw new SkipError("Process failed to execute.");
+					return;
+				}
+			}
+
 			boolean hasMonitorOrResultLink = false;
 			for (JsonNode currentJsonNode : linksArrayNode) {
+				System.out.println("currentNode: " + currentJsonNode.get("rel").asText());
 				// Fetch result document
 				if (currentJsonNode.get("rel").asText().equals("http://www.opengis.net/def/rel/ogc/1.0/results")) {
 
@@ -2423,6 +2434,8 @@ public class Jobs extends CommonFixture {
 					Assert.assertTrue(resultString.contains(TEST_STRING_INPUT),
 							"Response does not contain " + TEST_STRING_INPUT + "\n" + resultString);
 					hasMonitorOrResultLink = true;
+					System.out.println("currentNode (return): " + currentJsonNode.get("rel").asText());
+					return;
 				}
 
 			}
@@ -2446,12 +2459,13 @@ public class Jobs extends CommonFixture {
 						attempts++;
 						loopOverStatus(resultNode);
 						hasMonitorOrResultLink = true;
+						System.out.println("currentNode (return): " + relString);
+						return;
 					}
 				}
 			// if the code gets to this position, no result or monitor link were found
 			// imho we need to throw an exception
-			if (!hasMonitorOrResultLink)
-				throw new AssertionError(
+			throw new AssertionError(
 					"No result (rel='http://www.opengis.net/def/rel/ogc/1.0/results') or monitor (rel='monitor') links were found in response.");
 
 		}
@@ -2519,6 +2533,7 @@ public class Jobs extends CommonFixture {
 			}
 			catch (Exception e) {
 				Assert.fail(e.getLocalizedMessage());
+
 			}
 		}
 		else {

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/jobs/Jobs.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/jobs/Jobs.java
@@ -2404,22 +2404,20 @@ public class Jobs extends CommonFixture {
 						MAX_ATTEMPTS * ASYNC_LOOP_WAITING_PERIOD / 1000));
 			}
 
-			HttpClient client = HttpClientBuilder.create().build();
-			ArrayNode linksArrayNode = (ArrayNode) responseNode.get("links");
-
 			JsonNode statusNode = responseNode.get("status");
 
 			if (statusNode != null) {
 				String statusNodeText = statusNode.asText();
 				if (statusNodeText.equals("failed")) {
-					throw new SkipError("Process failed to execute.");
-					return;
+					throw new SkipException("Process failed to execute.");
 				}
 			}
 
+			HttpClient client = HttpClientBuilder.create().build();
+			ArrayNode linksArrayNode = (ArrayNode) responseNode.get("links");
+
 			boolean hasMonitorOrResultLink = false;
 			for (JsonNode currentJsonNode : linksArrayNode) {
-				System.out.println("currentNode: " + currentJsonNode.get("rel").asText());
 				// Fetch result document
 				if (currentJsonNode.get("rel").asText().equals("http://www.opengis.net/def/rel/ogc/1.0/results")) {
 


### PR DESCRIPTION
This change ensures that AssertionException is only thrown when the loopOverStatus method is invoked and no link with relation type `result` or `monitor` is found, as reported in #95.

My understanding of the previous code is that the function throws an exception even if a `results` or `monitor` relation type is found. 