### PR TITLE
Set maven-fluido-skin to version 2.0.1, restore deleted resources 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,11 @@
           <exclude>**/testdata/*.*</exclude>
         </excludes>
       </resource>
+      <resource>
+        <directory>src/main/javadoc</directory>
+        <filtering>true</filtering>
+        <targetPath>doc/${ets-code}/${project.version}</targetPath>
+      </resource>
     </resources>
   </build>
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -7,7 +7,7 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.5</version>
+    <version>2.0.1</version>
   </skin>
   <custom>
     <fluidoSkin>


### PR DESCRIPTION
Fix maven-fluido-skin version an restore deleted resources (https://github.com/opengeospatial/ets-ogcapi-processes10/commit/7410251ef0e2153008a61c9275ce61b2727199f7), context in https://github.com/opengeospatial/cite-private/issues/395.