### PR TITLE
Add token flow support and UUID validation for process/job IDs

### DIFF
--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/CommonFixture.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/CommonFixture.java
@@ -71,6 +71,8 @@ public class CommonFixture {
 
 	protected int limit = -1;
 
+    protected String authorizationToken;
+
 	protected boolean testAllProcesses = false;
 
 	/** A String representing the request. */
@@ -106,6 +108,8 @@ public class CommonFixture {
 		initLogging();
 		rootUri = (URI) testContext.getSuite().getAttribute(SuiteAttribute.IUT.getName());
 		limit = (Integer) testContext.getSuite().getAttribute(SuiteAttribute.PROCESS_TEST_LIMIT.getName());
+        // Initialize authorization token
+        authorizationToken = (String) testContext.getSuite().getAttribute(SuiteAttribute.TOKEN.getName());
 		boolean useLocalSchema = (boolean) testContext.getSuite()
 			.getAttribute(SuiteAttribute.USE_LOCAL_SCHEMA.getName());
 		if (useLocalSchema) {
@@ -158,7 +162,7 @@ public class CommonFixture {
 	 * @return a {@link io.restassured.specification.RequestSpecification} object
 	 */
 	protected RequestSpecification init() {
-		return given().filters(requestLoggingFilter, responseLoggingFilter).log().all();
+        return given().header("Authorization", authorizationToken).filters(requestLoggingFilter, responseLoggingFilter).log().all();
 	}
 
 	/**

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/SuiteAttribute.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/SuiteAttribute.java
@@ -17,93 +17,98 @@ import jakarta.ws.rs.client.Client;
 @SuppressWarnings("rawtypes")
 public enum SuiteAttribute {
 
-	/**
-	 * A client component for interacting with HTTP endpoints.
-	 */
-	CLIENT("httpClient", Client.class),
+    /**
+     * A client component for interacting with HTTP endpoints.
+     */
+    CLIENT("httpClient", Client.class),
 
-	/**
-	 * The root URL.
-	 */
-	IUT("instanceUnderTest", URI.class),
+    /**
+     * The root URL.
+     */
+    IUT("instanceUnderTest", URI.class),
 
-	/**
-	 * A File containing the test subject or a description of it.
-	 */
-	TEST_SUBJ_FILE("testSubjectFile", File.class),
+    /**
+     * A File containing the test subject or a description of it.
+     */
+    TEST_SUBJ_FILE("testSubjectFile", File.class),
 
-	/**
-	 * The number of collections to test.
-	 */
-	NO_OF_COLLECTIONS("noOfCollections", Integer.class),
+    /**
+     * The number of collections to test.
+     */
+    NO_OF_COLLECTIONS("noOfCollections", Integer.class),
 
-	/**
-	 * The id of the echo process.
-	 */
-	ECHO_PROCESS_ID("echoProcessId", String.class),
+    /**
+     * The id of the echo process.
+     */
+    ECHO_PROCESS_ID("echoProcessId", String.class),
 
-	/**
-	 * Boolean indicating whether all processes should be tested against the OGC Process
-	 * Description Conformance Class.
-	 */
-	TEST_ALL_PROCESSES("testAllProcesses", Boolean.class),
+    /**
+     * Boolean indicating whether all processes should be tested against the OGC Process
+     * Description Conformance Class.
+     */
+    TEST_ALL_PROCESSES("testAllProcesses", Boolean.class),
 
-	/**
-	 * Number of processes that should be tested against the OGC Process Description
-	 * Conformance Class.
-	 */
-	PROCESS_TEST_LIMIT("processTestLimit", Integer.class),
+    /**
+     * Number of processes that should be tested against the OGC Process Description
+     * Conformance Class.
+     */
+    PROCESS_TEST_LIMIT("processTestLimit", Integer.class),
 
-	/**
-	 * Parsed OpenApi3 document resource /api; Added during execution.
-	 */
-	API_MODEL("apiModel", OpenApi3.class),
+    /**
+     * Parsed OpenApi3 document resource /api; Added during execution.
+     */
+    API_MODEL("apiModel", OpenApi3.class),
 
-	/**
-	 * Use local OpenAPI schema included in ETS.
-	 */
-	USE_LOCAL_SCHEMA("useLocalSchema", Boolean.class),
+    /**
+     * Use local OpenAPI schema included in ETS.
+     */
+    USE_LOCAL_SCHEMA("useLocalSchema", Boolean.class),
 
-	/**
-	 * Requirement classes parsed from /conformance; Added during execution.
-	 */
-	REQUIREMENTCLASSES("requirementclasses", List.class);
+    /**
+     * Requirement classes parsed from /conformance; Added during execution.
+     */
+    REQUIREMENTCLASSES("requirementclasses", List.class),
 
-	private final Class attrType;
+    /**
+     * Authorization token for API requests.
+     */
+    TOKEN("token", String.class);
 
-	private final String attrName;
+    private final Class attrType;
 
-	SuiteAttribute(String attrName, Class attrType) {
-		this.attrName = attrName;
-		this.attrType = attrType;
-	}
+    private final String attrName;
 
-	/**
-	 * <p>
-	 * getType.
-	 * </p>
-	 * @return a {@link java.lang.Class} object
-	 */
-	public Class getType() {
-		return attrType;
-	}
+    SuiteAttribute(String attrName, Class attrType) {
+        this.attrName = attrName;
+        this.attrType = attrType;
+    }
 
-	/**
-	 * <p>
-	 * getName.
-	 * </p>
-	 * @return a {@link java.lang.String} object
-	 */
-	public String getName() {
-		return attrName;
-	}
+    /**
+     * <p>
+     * getType.
+     * </p>
+     * @return a {@link java.lang.Class} object
+     */
+    public Class getType() {
+        return attrType;
+    }
 
-	/** {@inheritDoc} */
-	@Override
-	public String toString() {
-		StringBuilder sb = new StringBuilder(attrName);
-		sb.append('(').append(attrType.getName()).append(')');
-		return sb.toString();
-	}
+    /**
+     * <p>
+     * getName.
+     * </p>
+     * @return a {@link java.lang.String} object
+     */
+    public String getName() {
+        return attrName;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(attrName);
+        sb.append('(').append(attrType.getName()).append(')');
+        return sb.toString();
+    }
 
 }

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/SuiteFixtureListener.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/SuiteFixtureListener.java
@@ -85,6 +85,21 @@ public class SuiteFixtureListener implements ISuiteListener {
 							TestRunArg.ECHOPROCESSID.toString(), echoProcessId));
 		}
 
+        String token = params.get(TestRunArg.TOKEN.toString());
+        try {
+            if (token != null) {
+                suite.setAttribute(SuiteAttribute.TOKEN.getName(), token.trim());
+                TestSuiteLogger.log(Level.INFO, "Authorization token configured for test suite");
+            } else {
+                TestSuiteLogger.log(Level.INFO, "No authorization token provided - tests will run without authentication");
+            }
+        }
+        catch (NumberFormatException e) {
+            TestSuiteLogger.log(Level.WARNING,
+                    String.format("Could not parse parameter %s: %s. Expected is a valid string",
+                            TestRunArg.TOKEN.toString(), token));
+        }
+
 		String limit = params.get(TestRunArg.PROCESSTESTLIMIT.toString());
 		try {
 			if (limit != null) {

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/TestRunArg.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/TestRunArg.java
@@ -7,44 +7,49 @@ package org.opengis.cite.ogcapiprocesses10;
  */
 public enum TestRunArg {
 
-	/**
-	 * An absolute URI that refers to a representation of the test subject or metadata
-	 * about it.
-	 */
-	IUT,
+    /**
+     * An absolute URI that refers to a representation of the test subject or metadata
+     * about it.
+     */
+    IUT,
 
-	/**
-	 * The number of collections to test (a value less or equal to 0 means all
-	 * collections).
-	 */
-	NOOFCOLLECTIONS,
+    /**
+     * The number of collections to test (a value less or equal to 0 means all
+     * collections).
+     */
+    NOOFCOLLECTIONS,
 
-	/**
-	 * The id of the echo process.
-	 */
-	ECHOPROCESSID,
+    /**
+     * The id of the echo process.
+     */
+    ECHOPROCESSID,
 
-	/**
-	 * Limit of processes to be tested against the OGC Process Description Conformance
-	 * Class.
-	 */
-	PROCESSTESTLIMIT,
+    /**
+     * Limit of processes to be tested against the OGC Process Description Conformance
+     * Class.
+     */
+    PROCESSTESTLIMIT,
 
-	/**
-	 * Use local OpenAPI schema.
-	 */
-	USELOCALSCHEMA,
+    /**
+     * Use local OpenAPI schema.
+     */
+    USELOCALSCHEMA,
 
-	/**
-	 * Boolean indicating whether all processes should be tested against the OGC Process
-	 * Description Conformance Class.
-	 */
-	TESTALLPROCESSES;
+    /**
+     * Boolean indicating whether all processes should be tested against the OGC Process
+     * Description Conformance Class.
+     */
+    TESTALLPROCESSES,
 
-	/** {@inheritDoc} */
-	@Override
-	public String toString() {
-		return name().toLowerCase();
-	}
+    /**
+     * Authorization token for API requests.
+     */
+    TOKEN;
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
 
 }

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/joblist/JobList.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/joblist/JobList.java
@@ -121,6 +121,7 @@ public class JobList extends CommonFixture {
 			HttpClient client = HttpClientBuilder.create().build();
 			HttpUriRequest request = new HttpGet(getJobListURL.toString());
 			request.setHeader("Accept", "application/json");
+            request.setHeader("Authorization", authorizationToken);
 			this.reqEntity = request;
 			HttpResponse httpResponse = client.execute(request);
 			StringWriter writer = new StringWriter();
@@ -160,6 +161,7 @@ public class JobList extends CommonFixture {
 			HttpClient client = HttpClientBuilder.create().build();
 			HttpUriRequest request = new HttpGet(getJobListURL.toString());
 			request.setHeader("Accept", "application/json");
+            request.setHeader("Authorization", authorizationToken);
 			this.reqEntity = request;
 			HttpResponse httpResponse = client.execute(request);
 			StringWriter writer = new StringWriter();

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/jobs/Jobs.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/jobs/Jobs.java
@@ -217,6 +217,7 @@ public class Jobs extends CommonFixture {
 			HttpClient client = HttpClientBuilder.create().build();
 			HttpUriRequest request = new HttpGet(rootUri + echoProcessPath);
 			request.setHeader("Accept", "application/json");
+            request.setHeader("Authorization", authorizationToken);
 			HttpResponse httpResponse = client.execute(request);
 			StringWriter writer = new StringWriter();
 			String encoding = StandardCharsets.UTF_8.name();
@@ -246,6 +247,7 @@ public class Jobs extends CommonFixture {
 			HttpClient client = HttpClientBuilder.create().build();
 			HttpUriRequest request = new HttpGet(rootUri + echoProcessPath);
 			request.setHeader("Accept", "application/json");
+            request.setHeader("Authorization", authorizationToken);
 			HttpResponse httpResponse = client.execute(request);
 			StringWriter writer = new StringWriter();
 			String encoding = StandardCharsets.UTF_8.name();
@@ -1310,6 +1312,7 @@ public class Jobs extends CommonFixture {
 		HttpPost request = new HttpPost(executeEndpoint);
 		this.reqEntity = request;
 		request.setHeader("Accept", "application/json");
+        request.setHeader("Authorization", authorizationToken);
 		ContentType contentType = ContentType.APPLICATION_JSON;
 		request.setEntity(new StringEntity(executeNode.toString(), contentType));
 		return request;
@@ -1320,6 +1323,7 @@ public class Jobs extends CommonFixture {
 		this.reqEntity = request;
 		request.setHeader("Accept", "application/json");
 		request.setHeader("Prefer", "respond-async");
+        request.setHeader("Authorization", authorizationToken);
 		ContentType contentType = ContentType.APPLICATION_JSON;
 		request.setEntity(new StringEntity(executeNode.toString(), contentType));
 		HttpResponse httpResponse = clientBuilder.build().execute(request);
@@ -1431,6 +1435,7 @@ public class Jobs extends CommonFixture {
 				this.reqEntity = request;
 				request.setHeader("Accept", "application/json");
 				request.setHeader("Prefer", "respond-async ");
+                request.setHeader("Authorization", authorizationToken);
 				ContentType contentType = ContentType.APPLICATION_JSON;
 				request.setEntity(new StringEntity(executeNode.toString(), contentType));
 				httpResponse = client.execute(request);
@@ -1441,6 +1446,7 @@ public class Jobs extends CommonFixture {
 				client = HttpClientBuilder.create().build();
 				HttpGet statusRequest = new HttpGet(locationString);
 				request.setHeader("Accept", "application/json");
+                request.setHeader("Authorization", authorizationToken);
 				httpResponse = client.execute(statusRequest);
 				StringWriter writer = new StringWriter();
 				String encoding = StandardCharsets.UTF_8.name();
@@ -1643,6 +1649,7 @@ public class Jobs extends CommonFixture {
 		HttpGet request = new HttpGet(url);
 		this.reqEntity = request;
 		request.setHeader("Accept", acceptType);
+        request.setHeader("Authorization", authorizationToken);
 		return clientBuilder.build().execute(request);
 	}
 
@@ -1869,6 +1876,7 @@ public class Jobs extends CommonFixture {
 			HttpPost request = new HttpPost(executeEndpoint);
 			this.reqEntity = request;
 			request.setHeader("Accept", "application/json");
+            request.setHeader("Authorization", authorizationToken);
 			ContentType contentType = ContentType.APPLICATION_JSON;
 			request.setEntity(new StringEntity(executeNode.toString(), contentType));
 			HttpResponse httpResponse = client.execute(request);
@@ -2400,6 +2408,7 @@ public class Jobs extends CommonFixture {
 					if (currentJsonNode.get("rel").asText() == "monitor") {
 						HttpUriRequest request = new HttpGet(currentJsonNode.get("href").asText());
 						request.setHeader("Accept", "application/json");
+                        request.setHeader("Authorization", authorizationToken);
 						HttpResponse httpResponse = client.execute(request);
 						JsonNode resultNode = parseResponse(httpResponse);
 						loopOverStatus(resultNode);
@@ -2464,6 +2473,7 @@ public class Jobs extends CommonFixture {
 					if (relString.equals("monitor") || relString.equals("status")) {
 						HttpUriRequest request = new HttpGet(currentJsonNode.get("href").asText());
 						request.setHeader("Accept", "application/json");
+                        request.setHeader("Authorization", authorizationToken);
 						HttpResponse httpResponse = client.execute(request);
 						JsonNode resultNode = parseResponse(httpResponse);
 						try {
@@ -2694,6 +2704,7 @@ public class Jobs extends CommonFixture {
 				HttpPost request = new HttpPost(executeEndpoint);
 				request.setHeader("Accept", "application/json");
 				request.setHeader("Prefer", "respond-async ");
+                request.setHeader("Authorization", authorizationToken);
 				ContentType contentType = ContentType.APPLICATION_JSON;
 				request.setEntity(new StringEntity(executeNode.toString(), contentType));
 				HttpResponse httpResponse = client.execute(request);
@@ -2704,6 +2715,7 @@ public class Jobs extends CommonFixture {
 				client = HttpClientBuilder.create().build();
 				HttpGet statusRequest = new HttpGet(locationString);
 				request.setHeader("Accept", "application/json");
+                request.setHeader("Authorization", authorizationToken);
 				httpResponse = client.execute(statusRequest);
 				StringWriter writer = new StringWriter();
 				String encoding = StandardCharsets.UTF_8.name();

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/jobs/Jobs.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/jobs/Jobs.java
@@ -202,8 +202,8 @@ public class Jobs extends CommonFixture {
 			getResultValidator = new OperationValidator(openApi3, getResultPath, getResultOperation);
 			getJobsListURL = new URL(jobsListEndpointString);
 			getProcessesListURL = new URL(processListEndpointString);
-			getInvalidJobURL = new URL(jobsListEndpointString + "/invalid-job-" + UUID.randomUUID());
-			getInvalidJobResultURL = new URL(jobsListEndpointString + "/invalid-job-" + UUID.randomUUID() + "/results");
+			getInvalidJobURL = new URL(jobsListEndpointString + "/" + UUID.randomUUID());
+			getInvalidJobResultURL = new URL(jobsListEndpointString + "/" + UUID.randomUUID() + "/results");
 			clientBuilder = HttpClientBuilder.create();
 		}
 		catch (Exception e) {

--- a/src/main/java/org/opengis/cite/ogcapiprocesses10/process/Process.java
+++ b/src/main/java/org/opengis/cite/ogcapiprocesses10/process/Process.java
@@ -78,7 +78,7 @@ public class Process extends CommonFixture {
 			final Path path = openApi3.getPathItemByOperationId(OPERATION_ID_GET_PROCESS_DESCRIPTION);
 			final Operation operation = openApi3.getOperationById(OPERATION_ID_GET_PROCESS_DESCRIPTION);
 			getProcessDescriptionValidator = new OperationValidator(openApi3, path, operation);
-			getInvalidProcessURL = new URL(processListEndpointString + "/invalid-process-" + UUID.randomUUID());
+			getInvalidProcessURL = new URL(processListEndpointString + "/" + UUID.randomUUID());
 		}
 		catch (MalformedURLException | ResolutionException | ValidationException e) {
 			Assert.fail(


### PR DESCRIPTION
This PR introduces two main updates to the `ets-ogcapi-processes10` compliance tests:

1.Token flow support
- Added token-based authorization for Processes and Jobs endpoints.
- Ensures compliance tests work with secured OGC Resource Server deployments.

2. Invalid process/job ID fix
- Replaced hardcoded invalid-process-<UUID> and invalid-job-<UUID>with plain <UUID> for invalid process IDs.
- This aligns with the OGC Resource Server OpenAPI schema where processId and jobId are required to be strings with uuid format.